### PR TITLE
remove bibtex-ruby runtime dep

### DIFF
--- a/anystyle-cli.gemspec
+++ b/anystyle-cli.gemspec
@@ -20,7 +20,6 @@ Gem::Specification.new do |s|
   s.required_ruby_version = '>= 2.3'
 
   s.add_runtime_dependency('anystyle', '~>1.3')
-  s.add_runtime_dependency('bibtex-ruby', '~>5.1')
   s.add_runtime_dependency('gli', '~>2.17')
 
   s.files = `git ls-files`.split("\n") - %w{


### PR DESCRIPTION
Hello! Thanks for this project!

I had some trouble installing `anystyle-cli` alongside `anystyle` with bundler, which is due to `anystyle-cli` allowing the latest `anystyle` version, but being locked to an earlier `bibtex-ruby`. I checked the source and apparently `bibtex-ruby` is just a transitive dependency of the CLI, therefore it doesn't look to be necessary as a runtime dep?

After this change, I can install both `anystyle` and its CLI as part of the bundler project in their latest versions. Thought it might be useful! Thanks!