### PR TITLE
Compatibility with Ruby 3.2.0

### DIFF
--- a/anystyle-cli.gemspec
+++ b/anystyle-cli.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.executables  = ['anystyle']
   s.required_ruby_version = '>= 2.3'
 
-  s.add_runtime_dependency('anystyle', '~>1.3')
+  s.add_runtime_dependency('anystyle', '~>1.4')
   s.add_runtime_dependency('gli', '~>2.17')
 
   s.files = `git ls-files`.split("\n") - %w{

--- a/bin/anystyle
+++ b/bin/anystyle
@@ -66,22 +66,22 @@ pre do |opts|
 
   unless opts[:'finder-model'].nil?
     AnyStyle::Finder.defaults[:model] =
-      File.expand_path(opts[:'finder-model']).untaint
+      File.expand_path(opts[:'finder-model'])
   end
 
   unless opts[:'parser-model'].nil?
     AnyStyle::Parser.defaults[:model] =
-      File.expand_path(opts[:'parser-model']).untaint
+      File.expand_path(opts[:'parser-model'])
   end
 
   unless opts[:pdftotext].nil?
     AnyStyle::Finder.defaults[:pdftotext] =
-      opts[:pdftotext].untaint
+      opts[:pdftotext]
   end
 
   unless opts[:pdfinfo].nil?
     AnyStyle::Finder.defaults[:pdfinfo] =
-      opts[:pdfinfo].untaint
+      opts[:pdfinfo]
   end
 
   AnyStyle

--- a/lib/anystyle/cli/commands/check.rb
+++ b/lib/anystyle/cli/commands/check.rb
@@ -14,9 +14,9 @@ module AnyStyle
         def check(path)
           case path.extname
           when '.ttx'
-            AnyStyle.finder.check path.to_s.untaint
+            AnyStyle.finder.check path.to_s
           when '.xml'
-            AnyStyle.parser.check path.to_s.untaint
+            AnyStyle.parser.check path.to_s
           else
             raise ArgumentError, "cannot check untagged input: #{path}"
           end

--- a/lib/anystyle/cli/commands/find.rb
+++ b/lib/anystyle/cli/commands/find.rb
@@ -6,7 +6,7 @@ module AnyStyle
           set_output_folder args[1]
           walk args[0] do |path, base_path|
             say "Analyzing #{path.relative_path_from(base_path)} ..."
-            doc = find(path.to_s.untaint, params)
+            doc = find(path.to_s, params)
             ref = doc[0].references(normalize_blocks: !params[:solo])
 
             if ref.length == 0

--- a/lib/anystyle/cli/commands/parse.rb
+++ b/lib/anystyle/cli/commands/parse.rb
@@ -6,7 +6,7 @@ module AnyStyle
           set_output_folder args[1]
           walk args[0] do |path, base_path|
             say "Parsing #{path.relative_path_from(base_path)} ..."
-            dataset = parse(path.to_s.untaint)
+            dataset = parse(path.to_s)
             say "#{dataset.length} references found."
             each_format do |fmt|
               res = format(dataset, fmt)

--- a/lib/anystyle/cli/commands/train.rb
+++ b/lib/anystyle/cli/commands/train.rb
@@ -11,17 +11,17 @@ module AnyStyle
           if args[1].nil?
             model.save
           else
-            model.save File.expand_path(args[1]).untaint
+            model.save File.expand_path(args[1])
           end
         end
 
         def train(path)
           case
           when File.extname(path) == '.xml'
-            AnyStyle.parser.train path.to_s.untaint
+            AnyStyle.parser.train path.to_s
             AnyStyle.parser.model
           when File.directory?(path)
-            AnyStyle.finder.train Dir[File.join(path, '*.ttx')].map(&:untaint)
+            AnyStyle.finder.train Dir[File.join(path, '*.ttx')]
             AnyStyle.finder.model
           else
             raise ArgumentError, "cannot train input: #{path}"


### PR DESCRIPTION
Final PR!

This change removes taint checking, which has been deprecated since Ruby 2.7 and has no effect.

Ruby 3.2.0 completely removes taint support, so this gem currently fails to compile under that Ruby version.

I don't think this should have any negative consequences for older Ruby versions.

See this thread for more info and links to similar gems with c extensions having taint checking
removed: https://bugs.ruby-lang.org/issues/16131#note-24

_Related changes in other gems of the family:_ 
- `wapiti` in https://github.com/inukshuk/wapiti-ruby/pull/9 
- `anystyle-data` in https://github.com/inukshuk/anystyle-data/pull/2
- `anystyle` in https://github.com/inukshuk/anystyle/pull/202